### PR TITLE
feat: folder upload support

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -30,6 +30,9 @@ components:
         uploaded:
           type: string
           format: date-time
+        path:
+          type: string
+          description: Relative directory path, e.g. "reports/2025"
     Session:
       type: object
       required:
@@ -228,6 +231,11 @@ paths:
                   items:
                     type: string
                     format: binary
+                paths:
+                  type: array
+                  items:
+                    type: string
+                  description: Relative directory path for each file (parallel to files array)
       responses:
         '201':
           description: Uploaded files

--- a/apps/api/src/api/server.ts
+++ b/apps/api/src/api/server.ts
@@ -131,12 +131,14 @@ async function handleRequest(
   if (filesSessionId && request.method === 'POST') {
     const formData = await request.formData();
     const files = formData.getAll('files').filter((value): value is File => value instanceof File);
+    const paths = formData.getAll('paths').map((v) => String(v));
     const uploaded = await addFilesToSession(
       config.inboxPath,
       filesSessionId,
       files,
       config.maxFileSize,
       config.unzipEnabled,
+      paths.length > 0 ? paths : undefined,
     );
 
     return Response.json({ uploaded }, { status: 201 });

--- a/apps/api/src/storage/sessionStore.ts
+++ b/apps/api/src/storage/sessionStore.ts
@@ -348,6 +348,10 @@ export async function addFilesToSession(
       throw new HttpError(400, 'No files provided');
     }
 
+    if (paths && paths.length !== files.length) {
+      throw new HttpError(400, 'paths array must match files array length');
+    }
+
     for (const file of files) {
       if (file.size > maxFileSize) {
         throw new HttpError(413, `File too large: ${file.name}`);

--- a/apps/api/src/storage/sessionStore.ts
+++ b/apps/api/src/storage/sessionStore.ts
@@ -157,6 +157,16 @@ export async function deleteSession(inboxPath: string, sessionId: string): Promi
   }
 }
 
+function safePath(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  const normalized = raw
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter((seg) => seg !== '..' && seg !== '.' && seg.length > 0)
+    .join('/');
+  return normalized || undefined;
+}
+
 function safeName(fileName: string): string {
   const base = basename(fileName).replace(/\s+/g, ' ').trim();
   const normalized = base.replace(/[^a-zA-Z0-9._ -]/g, '_');
@@ -229,18 +239,21 @@ async function storeOneFile(
   fileName: string,
   bytes: ArrayBuffer | Uint8Array,
   mime: string,
+  path?: string,
 ): Promise<FileEntry> {
   const folder = sessionDir(inboxPath, sessionId);
   const finalName = await resolveCollision(folder, fileName);
   await Bun.write(join(folder, finalName), bytes);
 
   const size = bytes instanceof ArrayBuffer ? bytes.byteLength : bytes.byteLength;
-  return {
+  const entry: FileEntry = {
     name: finalName,
     size,
     mime,
     uploaded: new Date().toISOString(),
   };
+  if (path) entry.path = path;
+  return entry;
 }
 
 async function unzipIntoSession(
@@ -323,6 +336,7 @@ export async function addFilesToSession(
   files: File[],
   maxFileSize: number,
   unzipEnabled: boolean,
+  paths?: string[],
 ): Promise<FileEntry[]> {
   return withSessionLock(sessionId, async () => {
     const session = await getSession(inboxPath, sessionId);
@@ -342,7 +356,9 @@ export async function addFilesToSession(
 
     const uploaded: FileEntry[] = [];
 
-    for (const file of files) {
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]!;
+      const filePath = safePath(paths?.[i]);
       const bytes = new Uint8Array(await file.arrayBuffer());
       const isZip = shouldUnzip(file, bytes);
       if (unzipEnabled && isZip) {
@@ -357,6 +373,7 @@ export async function addFilesToSession(
         file.name,
         bytes,
         file.type || mimeFromName(file.name),
+        filePath,
       );
       uploaded.push(item);
     }

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -5,6 +5,7 @@ export type FileEntry = {
   size: number;
   mime: string;
   uploaded: string;
+  path?: string;
 };
 
 export type Session = {

--- a/apps/ui/src/components/SessionList.tsx
+++ b/apps/ui/src/components/SessionList.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   FolderOpen,
+  Folder,
   Cloud,
   Loader2,
 } from "lucide-react";
@@ -31,7 +32,53 @@ import { useClient } from "@/hooks/use-client";
 import { useAuth } from "@/hooks/use-auth";
 import { formatBytes, formatDate } from "@/lib/format";
 import { toast } from "sonner";
-import type { Session } from "@filegate/sdk";
+import type { Session, FileEntry } from "@filegate/sdk";
+
+type TreeNode =
+  | { kind: "folder"; name: string; children: TreeNode[] }
+  | { kind: "file"; entry: FileEntry };
+
+function buildFileTree(files: FileEntry[]): TreeNode[] {
+  const hasAnyPath = files.some((f) => f.path);
+  if (!hasAnyPath) {
+    return files.map((entry) => ({ kind: "file", entry }));
+  }
+
+  const root: Map<string, TreeNode> = new Map();
+  const folderNodes = new Map<string, TreeNode & { kind: "folder" }>();
+
+  function ensureFolder(path: string): TreeNode & { kind: "folder" } {
+    if (folderNodes.has(path)) return folderNodes.get(path)!;
+    const parts = path.split("/");
+    const name = parts[parts.length - 1]!;
+    const node: TreeNode & { kind: "folder" } = {
+      kind: "folder",
+      name,
+      children: [],
+    };
+    folderNodes.set(path, node);
+
+    if (parts.length > 1) {
+      const parent = ensureFolder(parts.slice(0, -1).join("/"));
+      parent.children.push(node);
+    } else {
+      root.set(path, node);
+    }
+    return node;
+  }
+
+  for (const entry of files) {
+    const fileNode: TreeNode = { kind: "file", entry };
+    if (entry.path) {
+      const folder = ensureFolder(entry.path);
+      folder.children.push(fileNode);
+    } else {
+      root.set(`__file_${entry.name}`, fileNode);
+    }
+  }
+
+  return Array.from(root.values());
+}
 
 const POLL_INTERVAL = 30_000;
 
@@ -113,6 +160,54 @@ export function SessionList({ refreshKey }: Props) {
       }
       toast.error("Error en descarregar");
     }
+  }
+
+  function renderTree(
+    nodes: TreeNode[],
+    sessionId: string,
+    depth: number,
+  ): React.ReactNode[] {
+    return nodes.flatMap((node) => {
+      if (node.kind === "folder") {
+        return [
+          <div
+            key={`folder-${node.name}-${depth}`}
+            className="flex items-center gap-3 py-2 px-2"
+            style={{ paddingLeft: depth * 16 }}
+          >
+            <Folder className="size-4 text-amber-400 shrink-0" />
+            <span className="text-sm text-muted-foreground font-medium">
+              {node.name}
+            </span>
+          </div>,
+          ...renderTree(node.children, sessionId, depth + 1),
+        ];
+      }
+      return [
+        <div
+          key={node.entry.name}
+          className="flex items-center gap-3 py-2 px-2 rounded-lg hover:bg-white/60 transition-colors group"
+          style={{ paddingLeft: depth * 16 }}
+        >
+          <FileIcon fileName={node.entry.name} />
+          <span className="text-sm truncate flex-1">
+            {node.entry.name}
+          </span>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {formatBytes(node.entry.size)}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => handleDownload(sessionId, node.entry.name)}
+            title="Descarregar"
+            className="opacity-0 group-hover:opacity-100 transition-opacity"
+          >
+            <Download />
+          </Button>
+        </div>,
+      ];
+    });
   }
 
   if (loading) {
@@ -249,31 +344,11 @@ export function SessionList({ refreshKey }: Props) {
                   <CardContent className="p-0">
                     <Separator />
                     <div className="bg-muted/20 px-4 py-3 pl-14 space-y-0.5">
-                      {session.files.map((file) => (
-                        <div
-                          key={file.name}
-                          className="flex items-center gap-3 py-2 px-2 rounded-lg hover:bg-white/60 transition-colors group"
-                        >
-                          <FileIcon fileName={file.name} />
-                          <span className="text-sm truncate flex-1">
-                            {file.name}
-                          </span>
-                          <span className="text-xs text-muted-foreground shrink-0">
-                            {formatBytes(file.size)}
-                          </span>
-                          <Button
-                            variant="ghost"
-                            size="icon-xs"
-                            onClick={() =>
-                              handleDownload(session.id, file.name)
-                            }
-                            title="Descarregar"
-                            className="opacity-0 group-hover:opacity-100 transition-opacity"
-                          >
-                            <Download />
-                          </Button>
-                        </div>
-                      ))}
+                      {renderTree(
+                        buildFileTree(session.files),
+                        session.id,
+                        0,
+                      )}
                     </div>
                   </CardContent>
                 )}

--- a/apps/ui/src/components/SessionList.tsx
+++ b/apps/ui/src/components/SessionList.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   ChevronRight,
   FolderOpen,
+  Folder,
   Inbox,
   Loader2,
 } from "lucide-react";
@@ -17,7 +18,49 @@ import { useClient } from "@/hooks/use-client";
 import { useAuth } from "@/hooks/use-auth";
 import { formatBytes, formatDate } from "@/lib/format";
 import { toast } from "sonner";
-import type { Session } from "@filegate/sdk";
+import type { Session, FileEntry } from "@filegate/sdk";
+
+type TreeNode =
+  | { kind: "folder"; name: string; children: TreeNode[] }
+  | { kind: "file"; entry: FileEntry };
+
+function buildFileTree(files: FileEntry[]): TreeNode[] {
+  const hasAnyPath = files.some((f) => f.path);
+  if (!hasAnyPath) {
+    return files.map((entry) => ({ kind: "file", entry }));
+  }
+
+  const root: Map<string, TreeNode> = new Map();
+  const folderNodes = new Map<string, TreeNode & { kind: "folder" }>();
+
+  function ensureFolder(path: string): TreeNode & { kind: "folder" } {
+    if (folderNodes.has(path)) return folderNodes.get(path)!;
+    const parts = path.split("/");
+    const name = parts[parts.length - 1]!;
+    const node: TreeNode & { kind: "folder" } = { kind: "folder", name, children: [] };
+    folderNodes.set(path, node);
+
+    if (parts.length > 1) {
+      const parent = ensureFolder(parts.slice(0, -1).join("/"));
+      parent.children.push(node);
+    } else {
+      root.set(path, node);
+    }
+    return node;
+  }
+
+  for (const entry of files) {
+    const fileNode: TreeNode = { kind: "file", entry };
+    if (entry.path) {
+      const folder = ensureFolder(entry.path);
+      folder.children.push(fileNode);
+    } else {
+      root.set(`__file_${entry.name}`, fileNode);
+    }
+  }
+
+  return Array.from(root.values());
+}
 
 const POLL_INTERVAL = 30_000;
 
@@ -100,6 +143,50 @@ export function SessionList({ refreshKey }: Props) {
       }
       toast.error("Error en descarregar");
     }
+  }
+
+  function renderTree(nodes: TreeNode[], sessionId: string, depth: number): React.ReactNode[] {
+    return nodes.flatMap((node) => {
+      if (node.kind === "folder") {
+        return [
+          <div
+            key={`folder-${node.name}-${depth}`}
+            className="flex items-center gap-2.5 text-xs py-1.5"
+            style={{ paddingLeft: depth * 16 }}
+          >
+            <Folder className="size-3.5 text-amber-400 shrink-0" />
+            <span className="text-muted-foreground font-medium">
+              {node.name}
+            </span>
+          </div>,
+          ...renderTree(node.children, sessionId, depth + 1),
+        ];
+      }
+      return [
+        <div
+          key={node.entry.name}
+          className="flex items-center gap-2.5 text-xs py-1.5 group"
+          style={{ paddingLeft: depth * 16 }}
+        >
+          <FileIcon fileName={node.entry.name} />
+          <span className="truncate flex-1 text-foreground/70">
+            {node.entry.name}
+          </span>
+          <span className="text-muted-foreground shrink-0">
+            {formatBytes(node.entry.size)}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => handleDownload(sessionId, node.entry.name)}
+            title="Descarregar"
+            className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground"
+          >
+            <Download />
+          </Button>
+        </div>,
+      ];
+    });
   }
 
   if (loading) {
@@ -205,29 +292,7 @@ export function SessionList({ refreshKey }: Props) {
             {isOpen && session.files.length > 0 && (
               <div className="border-t border-border/40 bg-slate-50/50 px-4 py-3">
                 <div className="space-y-1.5">
-                  {session.files.map((file) => (
-                    <div
-                      key={file.name}
-                      className="flex items-center gap-2.5 text-xs py-1.5 group"
-                    >
-                      <FileIcon fileName={file.name} />
-                      <span className="truncate flex-1 text-foreground/70">
-                        {file.name}
-                      </span>
-                      <span className="text-muted-foreground shrink-0">
-                        {formatBytes(file.size)}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={() => handleDownload(session.id, file.name)}
-                        title="Descarregar"
-                        className="opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground"
-                      >
-                        <Download />
-                      </Button>
-                    </div>
-                  ))}
+                  {renderTree(buildFileTree(session.files), session.id, 0)}
                 </div>
               </div>
             )}

--- a/apps/ui/src/components/UploadDialog.tsx
+++ b/apps/ui/src/components/UploadDialog.tsx
@@ -31,6 +31,13 @@ import { useAuth } from "@/hooks/use-auth";
 import { formatBytes } from "@/lib/format";
 import { toast } from "sonner";
 import type { Session } from "@filegate/sdk";
+import {
+  type FileWithPath,
+  fileDedupKey,
+  fileDisplayDir,
+  handleFileSelect,
+  handleFolderDrop,
+} from "@/lib/folder";
 
 type Step = 1 | 2 | 3;
 
@@ -66,10 +73,11 @@ export function UploadDialog({ open, onOpenChange, onUploaded }: Props) {
   const client = useClient();
   const { logout } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
 
   const [step, setStep] = useState<Step>(1);
   const [direction, setDirection] = useState(0);
-  const [files, setFiles] = useState<File[]>([]);
+  const [files, setFiles] = useState<FileWithPath[]>([]);
   const [label, setLabel] = useState("");
   const [dragOver, setDragOver] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -77,11 +85,10 @@ export function UploadDialog({ open, onOpenChange, onUploaded }: Props) {
   const [session, setSession] = useState<Session | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const addFiles = useCallback((incoming: FileList | File[]) => {
-    const arr = Array.from(incoming);
+  const addFiles = useCallback((incoming: FileWithPath[]) => {
     setFiles((prev) => {
-      const existing = new Set(prev.map((f) => `${f.name}:${f.size}`));
-      const deduped = arr.filter((f) => !existing.has(`${f.name}:${f.size}`));
+      const existing = new Set(prev.map(fileDedupKey));
+      const deduped = incoming.filter((f) => !existing.has(fileDedupKey(f)));
       return [...prev, ...deduped];
     });
   }, []);
@@ -265,11 +272,13 @@ export function UploadDialog({ open, onOpenChange, onUploaded }: Props) {
                     setDragOver(true);
                   }}
                   onDragLeave={() => setDragOver(false)}
-                  onDrop={(e: React.DragEvent) => {
+                  onDrop={async (e: React.DragEvent) => {
                     e.preventDefault();
                     setDragOver(false);
-                    if (e.dataTransfer.files.length)
-                      addFiles(e.dataTransfer.files);
+                    const handled = await handleFolderDrop(e, addFiles);
+                    if (!handled && e.dataTransfer.files.length) {
+                      addFiles(Array.from(e.dataTransfer.files));
+                    }
                   }}
                 >
                   <input
@@ -277,10 +286,14 @@ export function UploadDialog({ open, onOpenChange, onUploaded }: Props) {
                     type="file"
                     multiple
                     className="hidden"
-                    onChange={(e) => {
-                      if (e.target.files?.length) addFiles(e.target.files);
-                      e.target.value = "";
-                    }}
+                    onChange={(e) => handleFileSelect(e, addFiles)}
+                  />
+                  <input
+                    ref={folderInputRef}
+                    type="file"
+                    className="hidden"
+                    {...({ webkitdirectory: "", directory: "" } as any)}
+                    onChange={(e) => handleFileSelect(e, addFiles)}
                   />
 
                   <CardContent
@@ -292,21 +305,34 @@ export function UploadDialog({ open, onOpenChange, onUploaded }: Props) {
                           <CloudUpload className="size-5 text-primary" />
                         </div>
                         <p className="text-sm text-foreground/70">
-                          Arrossega els arxius aquí
+                          Arrossega arxius o carpetes aquí
                         </p>
                         <p className="text-xs text-muted-foreground mt-1">
                           o{" "}
                           <span className="text-primary font-medium">
-                            fes clic per seleccionar
+                            selecciona arxius
                           </span>
+                          {" "}o{" "}
+                          <button
+                            type="button"
+                            className="text-primary font-medium hover:underline"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              folderInputRef.current?.click();
+                            }}
+                          >
+                            selecciona una carpeta
+                          </button>
                         </p>
                       </div>
                     ) : (
                       <div className="space-y-2">
                         <AnimatePresence>
-                          {files.map((file, i) => (
+                          {files.map((file, i) => {
+                            const dir = fileDisplayDir(file);
+                            return (
                             <motion.div
-                              key={`${file.name}-${file.size}`}
+                              key={fileDedupKey(file)}
                               initial={{ opacity: 0, height: 0 }}
                               animate={{ opacity: 1, height: "auto" }}
                               exit={{ opacity: 0, height: 0 }}
@@ -318,6 +344,7 @@ export function UploadDialog({ open, onOpenChange, onUploaded }: Props) {
                                 className="size-5"
                               />
                               <span className="text-sm truncate flex-1">
+                                {dir && <span className="text-muted-foreground text-xs">{dir}/</span>}
                                 {file.name}
                               </span>
                               <Badge variant="secondary" className="shrink-0">
@@ -335,7 +362,8 @@ export function UploadDialog({ open, onOpenChange, onUploaded }: Props) {
                                 <X className="size-3" />
                               </Button>
                             </motion.div>
-                          ))}
+                            );
+                          })}
                         </AnimatePresence>
                         <Button
                           variant="ghost"

--- a/apps/ui/src/components/UploadZone.tsx
+++ b/apps/ui/src/components/UploadZone.tsx
@@ -18,6 +18,8 @@ import { formatBytes } from "@/lib/format";
 import { toast } from "sonner";
 import type { Session } from "@filegate/sdk";
 
+type FileWithPath = File & { relativePath?: string };
+
 type UploadState =
   | { phase: "idle" }
   | { phase: "uploading"; progress: number }
@@ -29,21 +31,56 @@ interface Props {
 
 const UPLOAD_URL = "https://upload.498as.com";
 
+function tagRelativePath(file: File, path: string): FileWithPath {
+  return Object.assign(file, { relativePath: path });
+}
+
+async function traverseEntry(entry: FileSystemEntry): Promise<FileWithPath[]> {
+  if (entry.isFile) {
+    return new Promise((resolve) => {
+      (entry as FileSystemFileEntry).file((f) => {
+        resolve([tagRelativePath(f, entry.fullPath.replace(/^\//, ""))]);
+      });
+    });
+  }
+  if (entry.isDirectory) {
+    const reader = (entry as FileSystemDirectoryEntry).createReader();
+    const entries = await new Promise<FileSystemEntry[]>((resolve) => {
+      const all: FileSystemEntry[] = [];
+      const readBatch = () => {
+        reader.readEntries((batch) => {
+          if (batch.length === 0) return resolve(all);
+          all.push(...batch);
+          readBatch();
+        });
+      };
+      readBatch();
+    });
+    const nested = await Promise.all(entries.map(traverseEntry));
+    return nested.flat();
+  }
+  return [];
+}
+
 export function UploadZone({ onUploaded }: Props) {
   const client = useClient();
   const { logout } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [files, setFiles] = useState<File[]>([]);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<FileWithPath[]>([]);
   const [label, setLabel] = useState("");
   const [dragOver, setDragOver] = useState(false);
   const [state, setState] = useState<UploadState>({ phase: "idle" });
   const [copied, setCopied] = useState(false);
 
-  const addFiles = useCallback((incoming: FileList | File[]) => {
-    const arr = Array.from(incoming);
+  const addFiles = useCallback((incoming: FileWithPath[]) => {
     setFiles((prev) => {
-      const existing = new Set(prev.map((f) => `${f.name}:${f.size}`));
-      const deduped = arr.filter((f) => !existing.has(`${f.name}:${f.size}`));
+      const existing = new Set(
+        prev.map((f) => `${f.relativePath ?? f.name}:${f.size}`),
+      );
+      const deduped = incoming.filter(
+        (f) => !existing.has(`${f.relativePath ?? f.name}:${f.size}`),
+      );
       return [...prev, ...deduped];
     });
   }, []);
@@ -164,10 +201,23 @@ export function UploadZone({ onUploaded }: Props) {
           setDragOver(true);
         }}
         onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => {
+        onDrop={async (e) => {
           e.preventDefault();
           setDragOver(false);
-          if (e.dataTransfer.files.length) addFiles(e.dataTransfer.files);
+          const items = e.dataTransfer.items;
+          if (items?.length) {
+            const entries = Array.from(items)
+              .map((item) => item.webkitGetAsEntry?.())
+              .filter((e): e is FileSystemEntry => e != null);
+            if (entries.length > 0) {
+              const nested = await Promise.all(entries.map(traverseEntry));
+              addFiles(nested.flat());
+              return;
+            }
+          }
+          if (e.dataTransfer.files.length) {
+            addFiles(Array.from(e.dataTransfer.files));
+          }
         }}
         onClick={() => fileInputRef.current?.click()}
       >
@@ -177,7 +227,29 @@ export function UploadZone({ onUploaded }: Props) {
           multiple
           className="hidden"
           onChange={(e) => {
-            if (e.target.files?.length) addFiles(e.target.files);
+            if (e.target.files?.length) {
+              addFiles(Array.from(e.target.files).map((f) =>
+                f.webkitRelativePath
+                  ? tagRelativePath(f, f.webkitRelativePath)
+                  : f,
+              ));
+            }
+            e.target.value = "";
+          }}
+        />
+        <input
+          ref={folderInputRef}
+          type="file"
+          className="hidden"
+          {...({ webkitdirectory: "", directory: "" } as any)}
+          onChange={(e) => {
+            if (e.target.files?.length) {
+              addFiles(Array.from(e.target.files).map((f) =>
+                f.webkitRelativePath
+                  ? tagRelativePath(f, f.webkitRelativePath)
+                  : f,
+              ));
+            }
             e.target.value = "";
           }}
         />
@@ -185,26 +257,45 @@ export function UploadZone({ onUploaded }: Props) {
           <CloudUpload className="size-6 text-primary" />
         </div>
         <p className="text-sm text-foreground/70">
-          Arrossega els arxius aquí
+          Arrossega arxius o carpetes aquí
         </p>
         <p className="text-xs text-muted-foreground mt-1">
           o{" "}
           <span className="text-primary font-medium">
-            fes clic per seleccionar-los
+            selecciona arxius
           </span>
+          {" "}o{" "}
+          <button
+            type="button"
+            className="text-primary font-medium hover:underline"
+            onClick={(e) => {
+              e.stopPropagation();
+              folderInputRef.current?.click();
+            }}
+          >
+            selecciona una carpeta
+          </button>
         </p>
       </div>
 
       {/* File list */}
       {files.length > 0 && (
         <div className="space-y-2">
-          {files.map((file, i) => (
+          {files.map((file, i) => {
+            const rel = (file as FileWithPath).relativePath;
+            const dir = rel ? rel.replace(/[/\\][^/\\]*$/, "") : "";
+            return (
             <div
-              key={`${file.name}-${i}`}
+              key={`${rel ?? file.name}-${i}`}
               className="flex items-center gap-3 text-sm bg-white rounded-xl border border-border/60 px-3.5 py-3 group shadow-sm"
             >
               <FileIcon fileName={file.name} className="size-5" />
               <span className="truncate flex-1 text-foreground/80">
+                {dir && (
+                  <span className="text-muted-foreground text-xs">
+                    {dir}/
+                  </span>
+                )}
                 {file.name}
               </span>
               <span className="text-muted-foreground text-xs shrink-0">
@@ -220,7 +311,8 @@ export function UploadZone({ onUploaded }: Props) {
                 <X className="size-4" />
               </button>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
 

--- a/apps/ui/src/components/UploadZone.tsx
+++ b/apps/ui/src/components/UploadZone.tsx
@@ -16,6 +16,13 @@ import { useAuth } from "@/hooks/use-auth";
 import { formatBytes } from "@/lib/format";
 import { toast } from "sonner";
 import type { Session } from "@filegate/sdk";
+import {
+  type FileWithPath,
+  fileDedupKey,
+  fileDisplayDir,
+  handleFileSelect,
+  handleFolderDrop,
+} from "@/lib/folder";
 
 type UploadState =
   | { phase: "idle" }
@@ -32,17 +39,17 @@ export function UploadZone({ onUploaded }: Props) {
   const client = useClient();
   const { logout } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [files, setFiles] = useState<File[]>([]);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<FileWithPath[]>([]);
   const [label, setLabel] = useState("");
   const [dragOver, setDragOver] = useState(false);
   const [state, setState] = useState<UploadState>({ phase: "idle" });
   const [copied, setCopied] = useState(false);
 
-  const addFiles = useCallback((incoming: FileList | File[]) => {
-    const arr = Array.from(incoming);
+  const addFiles = useCallback((incoming: FileWithPath[]) => {
     setFiles((prev) => {
-      const existing = new Set(prev.map((f) => `${f.name}:${f.size}`));
-      const deduped = arr.filter((f) => !existing.has(`${f.name}:${f.size}`));
+      const existing = new Set(prev.map(fileDedupKey));
+      const deduped = incoming.filter((f) => !existing.has(fileDedupKey(f)));
       return [...prev, ...deduped];
     });
   }, []);
@@ -156,10 +163,13 @@ export function UploadZone({ onUploaded }: Props) {
           setDragOver(true);
         }}
         onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => {
+        onDrop={async (e) => {
           e.preventDefault();
           setDragOver(false);
-          if (e.dataTransfer.files.length) addFiles(e.dataTransfer.files);
+          const handled = await handleFolderDrop(e, addFiles);
+          if (!handled && e.dataTransfer.files.length) {
+            addFiles(Array.from(e.dataTransfer.files));
+          }
         }}
         onClick={() => fileInputRef.current?.click()}
       >
@@ -168,10 +178,14 @@ export function UploadZone({ onUploaded }: Props) {
           type="file"
           multiple
           className="hidden"
-          onChange={(e) => {
-            if (e.target.files?.length) addFiles(e.target.files);
-            e.target.value = "";
-          }}
+          onChange={(e) => handleFileSelect(e, addFiles)}
+        />
+        <input
+          ref={folderInputRef}
+          type="file"
+          className="hidden"
+          {...({ webkitdirectory: "", directory: "" } as any)}
+          onChange={(e) => handleFileSelect(e, addFiles)}
         />
 
         {files.length === 0 ? (
@@ -181,21 +195,34 @@ export function UploadZone({ onUploaded }: Props) {
               <CloudUpload className="size-7 text-primary" />
             </div>
             <p className="text-[15px] font-medium text-foreground/80">
-              Arrossega els arxius aquí
+              Arrossega arxius o carpetes aquí
             </p>
             <p className="text-sm text-muted-foreground mt-1.5">
               o{" "}
               <span className="text-primary font-medium">
-                fes clic per seleccionar-los
+                selecciona arxius
               </span>
+              {" "}o{" "}
+              <button
+                type="button"
+                className="text-primary font-medium hover:underline"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  folderInputRef.current?.click();
+                }}
+              >
+                selecciona una carpeta
+              </button>
             </p>
           </div>
         ) : (
           /* File grid — Drive-style cards */
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {files.map((file, i) => (
+            {files.map((file, i) => {
+              const dir = fileDisplayDir(file);
+              return (
               <div
-                key={`${file.name}-${i}`}
+                key={fileDedupKey(file)}
                 className="relative bg-white rounded-xl border border-border/60 p-3 shadow-sm group"
                 onClick={(e) => e.stopPropagation()}
               >
@@ -217,6 +244,9 @@ export function UploadZone({ onUploaded }: Props) {
 
                 {/* Info */}
                 <div className="pt-2 border-t border-border/40">
+                  {dir && (
+                    <p className="text-[10px] text-muted-foreground truncate">{dir}/</p>
+                  )}
                   <p className="text-xs font-medium truncate text-foreground/80">
                     {file.name}
                   </p>
@@ -225,7 +255,8 @@ export function UploadZone({ onUploaded }: Props) {
                   </p>
                 </div>
               </div>
-            ))}
+              );
+            })}
 
             {/* Add more */}
             <div className="flex items-center justify-center rounded-xl border-2 border-dashed border-border/60 hover:border-primary/30 transition-colors min-h-[120px]">

--- a/apps/ui/src/lib/folder.ts
+++ b/apps/ui/src/lib/folder.ts
@@ -1,0 +1,77 @@
+export type FileWithPath = File & { relativePath?: string };
+
+export function tagRelativePath(file: File, path: string): FileWithPath {
+  return Object.assign(file, { relativePath: path });
+}
+
+export async function traverseEntry(
+  entry: FileSystemEntry,
+): Promise<FileWithPath[]> {
+  if (entry.isFile) {
+    return new Promise((resolve) => {
+      (entry as FileSystemFileEntry).file((f) => {
+        resolve([tagRelativePath(f, entry.fullPath.replace(/^\//, ""))]);
+      });
+    });
+  }
+  if (entry.isDirectory) {
+    const reader = (entry as FileSystemDirectoryEntry).createReader();
+    const entries = await new Promise<FileSystemEntry[]>((resolve) => {
+      const all: FileSystemEntry[] = [];
+      const readBatch = () => {
+        reader.readEntries((batch) => {
+          if (batch.length === 0) return resolve(all);
+          all.push(...batch);
+          readBatch();
+        });
+      };
+      readBatch();
+    });
+    const nested = await Promise.all(entries.map(traverseEntry));
+    return nested.flat();
+  }
+  return [];
+}
+
+export function handleFileSelect(
+  e: React.ChangeEvent<HTMLInputElement>,
+  addFiles: (files: FileWithPath[]) => void,
+) {
+  if (e.target.files?.length) {
+    addFiles(
+      Array.from(e.target.files).map((f) =>
+        f.webkitRelativePath
+          ? tagRelativePath(f, f.webkitRelativePath)
+          : f,
+      ),
+    );
+  }
+  e.target.value = "";
+}
+
+export async function handleFolderDrop(
+  e: React.DragEvent,
+  addFiles: (files: FileWithPath[]) => void,
+): Promise<boolean> {
+  const items = e.dataTransfer.items;
+  if (items?.length) {
+    const entries = Array.from(items)
+      .map((item) => item.webkitGetAsEntry?.())
+      .filter((e): e is FileSystemEntry => e != null);
+    if (entries.length > 0) {
+      const nested = await Promise.all(entries.map(traverseEntry));
+      addFiles(nested.flat());
+      return true;
+    }
+  }
+  return false;
+}
+
+export function fileDedupKey(f: FileWithPath): string {
+  return `${f.relativePath ?? f.name}:${f.size}`;
+}
+
+export function fileDisplayDir(f: FileWithPath): string {
+  const rel = f.relativePath;
+  return rel ? rel.replace(/[/\\][^/\\]*$/, "") : "";
+}

--- a/packages/sdk/src/generated/types.ts
+++ b/packages/sdk/src/generated/types.ts
@@ -295,6 +295,8 @@ export type paths = {
                 content: {
                     "multipart/form-data": {
                         files?: string[];
+                        /** @description Relative directory path for each file (parallel to files array) */
+                        paths?: string[];
                     };
                 };
             };
@@ -463,6 +465,8 @@ export type components = {
         FileEntry: {
             mime: string;
             name: string;
+            /** @description Relative directory path, e.g. "reports/2025" */
+            path?: string;
             /** Format: int64 */
             size: number;
             /** Format: date-time */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -153,8 +153,23 @@ export class FilegateClient {
   readonly files = {
     upload: async (sessionId: string, files: File[] | FileList): Promise<FileEntry[]> => {
       const form = new FormData();
-      for (const file of Array.from(files)) {
+      let hasPaths = false;
+      const fileArr = Array.from(files);
+      const pathEntries: string[] = [];
+
+      for (const file of fileArr) {
         form.append('files', file);
+        const relativePath = (file as File & { relativePath?: string; webkitRelativePath?: string })
+          .relativePath ?? (file as File & { webkitRelativePath?: string }).webkitRelativePath ?? '';
+        const dir = relativePath ? relativePath.replace(/[/\\][^/\\]*$/, '') : '';
+        pathEntries.push(dir);
+        if (dir) hasPaths = true;
+      }
+
+      if (hasPaths) {
+        for (const p of pathEntries) {
+          form.append('paths', p);
+        }
       }
 
       const response = await this.fetchImpl(


### PR DESCRIPTION
## Summary
- Add `path` (optional) to `FileEntry` for directory metadata — files stay flat on disk
- API accepts `paths[]` in FormData parallel to `files[]`, with `safePath()` sanitization
- SDK reads `relativePath`/`webkitRelativePath` from files and sends dir paths automatically
- Upload zone supports folder selection (`webkitdirectory`) and drag-and-drop folder traversal via `webkitGetAsEntry()`
- Session list renders folder hierarchy with indentation + folder icons, falls back to flat list for legacy uploads

## Test plan
- [ ] Drag a folder into the drop zone → files listed with path prefixes
- [ ] Click "selecciona una carpeta" → native folder picker opens
- [ ] Upload folder → `session.json` has `path` on entries
- [ ] Session list shows folder tree hierarchy
- [ ] Mix files + folders in same upload
- [ ] Legacy sessions (no `path`) still render flat